### PR TITLE
changed conda download from NSISdl to inetc

### DIFF
--- a/conda.nsh
+++ b/conda.nsh
@@ -16,7 +16,7 @@ var CONDA     # Conda executable
   # Downloading miniconda
   SetOutPath "$TEMP\conda_installer"
   DetailPrint "Downloading Conda ..."
-  NSISdl::download /TIMEOUT=1800000 ${CONDA_URL} conda_setup.exe
+  inetc::get /NOCANCEL /RESUME "" ${CONDA_URL} conda_setup.exe
   !insertmacro _FinishMessage "Conda download"
 
   # Installing miniconda


### PR DESCRIPTION
I had problems with the NSISdl downloading of the conda installer, because it only supports HTTP and not HTTPS. The inetc plugin should fix that. But it requires that the inetc plugin is installed.